### PR TITLE
Removed es2015 preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react-native"]
+  "presets": ["react-native"]
 }


### PR DESCRIPTION
The es2015 preset is causing a couple errors, because React Native don't work with it, as explained here: http://stackoverflow.com/a/39016277