### PR TITLE
Adapted TextInpuMask in order to make it able to use any specialization of TextInput

### DIFF
--- a/lib/text-input-mask.js
+++ b/lib/text-input-mask.js
@@ -1,15 +1,18 @@
 import React, { Component } from 'react';
 import {
-  StyleSheet,
-  TextInput
+	StyleSheet,
+	TextInput
 } from 'react-native';
 import BaseTextComponent from './base-text-component';
 
 const INPUT_TEXT_REF = '$input-text';
 
+let Input = TextInput
+
 export default class TextInputMask extends BaseTextComponent {
 	constructor(props) {
 		super(props);
+		if (props.customTextInput) Input = props.customTextInput
 	}
 
 	getElement() {
@@ -19,20 +22,20 @@ export default class TextInputMask extends BaseTextComponent {
 	_onChangeText(text) {
 		let self = this;
 
-		if(!this._checkText(text)) {
+		if (!this._checkText(text)) {
 			return;
 		}
 
 		self.updateValue(text)
 			.then(maskedText => {
-				if(self.props.onChangeText) {
+				if (self.props.onChangeText) {
 					self.props.onChangeText(maskedText);
 				}
 			});
 	}
 
 	_checkText(text) {
-		if(this.props.checkText) {
+		if (this.props.checkText) {
 			return this.props.checkText(this.state.value, text);
 		}
 
@@ -41,13 +44,13 @@ export default class TextInputMask extends BaseTextComponent {
 
 	render() {
 		return (
-			<TextInput
+			<Input
 				ref={INPUT_TEXT_REF}
 				keyboardType={this._maskHandler.getKeyboardType()}
 				{...this.props}
 				onChangeText={(text) => this._onChangeText(text)}
 				value={this.state.value}
-				/>
+			/>
 		);
 	}
 }


### PR DESCRIPTION
Trying to conciliate your `TextInputMask` with the provided by `react-native-material-textfield`, I've done a simple modification.

Usage example:

```javascript
render() {
        // the type is required but options is required only for some specific types.

        return (
            <TextInputMask
                ref={'myDateText'}
                type={'datetime'}
                label="Hello"
                customTextInput={MaterialTextInput}
                options={{
                    format: 'DD-MM-YYYY HH:mm:ss'
                }} />
        );
    }
```

In `customTextInput`, now, is possible to insert any specialization of the native `TextInput` 

 