### PR TITLE
Allowed blank values in custom mask

### DIFF
--- a/lib/masks/custom.mask.js
+++ b/lib/masks/custom.mask.js
@@ -28,6 +28,9 @@ export default class CustomMask extends BaseMask {
 	}
 
 	getValue(value, settings) {
+		if (value === '') {
+			return value;
+		}
 		let { mask } = settings;
 		let translation = this.mergeSettings(DEFAULT_TRANSLATION, settings.translation);
 


### PR DESCRIPTION
The custom mask currently doesn't allow blank values once active. When the last character is deleted, it pops right back in. This is because tinymask returns `undefined` for blank values.