### PR TITLE
Add scaleRaw option to get integer value from money mask (e.g. cents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Some types accept options, use it like this: `<TextInputMask type={'money'} opti
 	* `unit`: (String, default 'R$'): the prefix text.
 	* `suffixUnit` (String, default ''): the suffix text.
 	* `zeroCents` (Boolean, default false): if must show cents.
+	* `scaleRaw` (Boolean, default true): if getRawValue returns scaled (1.23) or un-scaled (123) Number.
 
 **For `type={'cel-phone'}`** <br />
 * *options={...}*
@@ -404,6 +405,10 @@ var money = MaskService.toMask('money', '123', {
 
 
 # Changelog
+
+## 1.6.2
+* Add `scaleRaw` option to money mask. (thanks to [Cogwheel](https://github.com/cogwheel))
+
 ## 1.6.1
 * Fixing duplicated custom text input component. (thanks to [Pablo](https://github.com/rochapablo))
 

--- a/__tests__/money.mask.test.js
+++ b/__tests__/money.mask.test.js
@@ -173,6 +173,20 @@ test('1 zeroCents results R$1,00 and raw value 1', () => {
     expect(receivedRawValue).toBe(expectedRawValue);
 });
 
+test('1 scaleRaw false results R$0,01 and raw value 1', () => {
+    var mask = new MoneyMask();
+    var expected = 'R$0,01';
+    var received = mask.getValue('1');
+
+    var expectedRawValue = 1;
+    var receivedRawValue = mask.getRawValue(received, {
+        scaleRaw: false
+    });
+
+    expect(received).toBe(expected);
+    expect(receivedRawValue).toBe(expectedRawValue);
+});
+
 test('111111 delimiter , results R$1,111,11 and raw value 1111.11', () => {
     var mask = new MoneyMask();
     var expected = 'R$1,111,11';

--- a/lib/masks/money.mask.js
+++ b/lib/masks/money.mask.js
@@ -6,7 +6,8 @@ const MONEY_MASK_SETTINGS = {
     delimiter: '.',
     unit: 'R$',
     suffixUnit: '',
-    zeroCents: false
+    zeroCents: false,
+    scaleRaw: true
 };
 
 export default class MoneyMask extends BaseMask {
@@ -36,8 +37,11 @@ export default class MoneyMask extends BaseMask {
         let mergedSettings = super.mergeSettings(MONEY_MASK_SETTINGS, settings);
         let normalized = super.removeNotNumbers(maskedValue);
 
-        let dotPosition = normalized.length - mergedSettings.precision;
-        normalized = this._insert(normalized, dotPosition, '.');
+        if (mergedSettings.scaleRaw && mergedSettings.precision > 0) {
+            // turn 123 into 1.23 (given precision of 2)
+            let dotPosition = normalized.length - mergedSettings.precision;
+            normalized = this._insert(normalized, dotPosition, '.');
+        }
 
         return Number(normalized);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-masked-text",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Text and TextInput with mask for React Native applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We use integer "cents" throughout our systems rather than fractional numbers. Most currency/decimal data types offer the option to convert to either type of value, so this patch adds the feature to money mask.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/benhurott/react-native-masked-text/34)
<!-- Reviewable:end -->
