### PR TITLE
feat: Replace old legacy ref string by the new callback

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,58 @@
+{
+  "extends": [
+    "airbnb",
+    "plugin:flowtype/recommended",
+  ],
+  "plugins": [
+    "flowtype"
+  ],
+  "parser": "babel-eslint",
+    "parserOptions": {
+    "sourceType": "module",
+    "allowImportExportEverywhere": false,
+    "codeFrame": false
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es6": true,
+    "mocha": true,
+    "jest": true
+  },
+  "rules": {
+    "class-methods-use-this": [ 0, {
+      "exceptMethods": []
+    }],
+
+    "react/jsx-filename-extension": [ 1, {
+      "extensions": [".js", ".jsx"]
+    }],
+    "react/jsx-max-props-per-line": [ 1, {
+      "maximum": 2,
+      "when": "multiline"
+    }],
+    "react/prefer-stateless-function": [ 0, {} ],
+    "require-jsdoc": ["error", {
+        "require": {
+            "FunctionDeclaration": true,
+            "MethodDefinition": true,
+            "ClassDeclaration": true
+        }
+    }],
+    "react/sort-comp": [ 2, {
+      order: [
+        "type-annotations",
+        "static-methods",
+        "life-cycle",
+        "everything-else",
+        "render"
+      ]
+    }],
+    "valid-jsdoc": ["error", {
+      "requireReturn": true,
+      "requireReturnType": true,
+      "requireParamDescription": true,
+      "requireReturnDescription": true
+    }]
+  }
+}

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,53 @@
+[ignore]
+; We fork some components by platform
+.*/*[.]android.js
+
+; Ignore "BUCK" generated dirs
+<PROJECT_ROOT>/\.buckd/
+.*/node_modules/.*
+
+; Ignore unexpected extra "@providesModule"
+.*/node_modules/.*/node_modules/fbjs/.*
+
+; .*/node_modules/expo/.*
+
+; Ignore duplicate module providers
+; For RN Apps installed via npm, "Libraries" folder is inside
+; "node_modules/react-native" but in the source repo is inside the root
+.*/Libraries/react-native/React.js
+.*/Libraries/react-native/ReactNative.js
+
+[include]
+
+[libs]
+node_modules/react-native/Libraries/react-native/react-native-interface.js
+node_modules/react-native/flow
+flow/
+./flow-typed/
+
+[options]
+emoji=true
+
+module.system=haste
+
+esproposal.class_static_fields=enable
+esproposal.class_instance_fields=enable
+
+munge_underscores=true
+
+module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
+
+suppress_type=$FlowIssue
+suppress_type=$FlowFixMe
+suppress_type=$FixMe
+suppress_type=$FlowExpectedError
+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(4[0-7]\\|[1-3][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(4[0-7]\\|[1-3][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
+
+unsafe.enable_getters_and_setters=true
+
+[version]
+^0.52.0

--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ export default class MyComponent extends Component {
 		// isValid method returns if the inputed value is valid.
 		// Ex: if you input 40/02/1990 30:20:20, it will return false
 		//	   because in this case, the day and the hour is invalid.
-		let valid = this.refs['myDateText'].isValid();
+		let valid = this.myDateText.isValid();
 
 		// get converted value. Using type=datetime, it returns the moment object.
 		// If it's using type=money, it returns a Number object.
-		let rawValue = this.refs['myDateText'].getRawValue();
+		let rawValue = this.myDateText.getRawValue();
 	}
 
 	render() {
 		// the type is required but options is required only for some specific types.
 		return (
 			<TextInputMask
-				ref={'myDateText'}
+				refInput={(ref) => this.myDateText = ref;}
 				type={'datetime'}
 				options={{
 					format: 'DD-MM-YYYY HH:mm:ss'
@@ -113,7 +113,7 @@ const Textfield = MKTextField.textfield()
 
 
 <TextInputMask
-	ref={'myDateText'}
+	refInput={(ref) => this.myDateText = ref;}
 	type={'money'}
 	style={styles.input}
 	customTextInput={Textfield}
@@ -144,7 +144,7 @@ export default class App extends React.Component {
     return (
       <View style={styles.container}>
         <TextInputMask
-          ref={'myDateText'}
+          refInput={(ref) => this.myDateText = ref;}
           // here we set the custom component and their props.
           customTextInput={Kaede}
           customTextInputProps={{

--- a/lib/text-input-mask.js
+++ b/lib/text-input-mask.js
@@ -1,7 +1,8 @@
-import React, { Component } from 'react';
+// @flow
+import React from 'react';
 import {
 	StyleSheet,
-	TextInput
+	TextInput,
 } from 'react-native';
 import BaseTextComponent from './base-text-component';
 
@@ -50,7 +51,13 @@ export default class TextInputMask extends BaseTextComponent {
 
 		return (
 			<Input
-				ref={INPUT_TEXT_REF}
+				ref={(ref) => {
+					if(ref) {
+		        if (typeof this.props.refInput === 'function') {
+		          this.props.refInput(ref);
+		        }
+					}
+				}}
 				keyboardType={this._getKeyboardType()}
 				{...this.props}
 				{...customTextInputProps}


### PR DESCRIPTION
While perhaps more simple, the old refs API can get difficult in some edge cases, like when used in a callback. All kind of static analysis is a pain with strings, too. The callback based API can do everything the string API can do and more with just a little added verbosity.


The ref API is broken is several aspects.

- You have to refer to this.refs['myname'] as strings to be Closure Compiler Advanced Mode compatible.
- It doesn't allow the notion of multiple owners of a single instance.
- Magical dynamic strings potentially break optimizations in VMs.
- It needs to be always consistent, because it's synchronously resolved. This means that asynchronous batching of rendering introduces potential bugs.
- We currently have a hook to get sibling refs so that you can have one component refer to it's sibling as a context reference. This only works one level. This breaks the ability to wrap one of those in an encapsulation.
- It can't be statically typed. You have to cast it at any use in languages like TypeScript.
- There's no way to attach the ref to the correct "owner" in a callback invoked by a child. <Child renderer={index => <div ref="test">{index}</div>} /> -- this ref will be attached where the callback is issued, not in the current owner.


The docs call the old string API "legacy" to make it clearer that the callback-based API is the preferred approach, as is discussed in this commit and in this PR which are the ones that actually put those statements to the documentation in the first place. Also note that a few of the comments imply that the string based refs api might be deprecated at some point.