### PR TITLE
Update to Moment 2.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/benhurott/react-native-masked-text#readme",
   "dependencies": {
-    "moment": "^2.18.1",
+    "moment": "^2.19.1",
     "tinymask": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
There's an issue with the most recent version of React Native/Metro which means Moment.js v2.18.* no longer works:

https://github.com/facebook/metro-bundler/issues/65

This PR upgrades to Moment.js v2.19.1 which seems to fix the issue:

https://github.com/facebook/metro-bundler/issues/65#issuecomment-339015234