### PR TITLE
ZipCodeMask with empty string should be invalid

### DIFF
--- a/__tests__/zip-code.mask.test.js
+++ b/__tests__/zip-code.mask.test.js
@@ -52,3 +52,11 @@ test('11111111 results 11111-111 and raw value 11111111', () => {
     expect(received).toBe(expected);
     expect(receivedRawValue).toBe(expectedRawValue);
 });
+
+test('empty string is not valid', () => {
+    var mask = new ZipCodeMask();
+    var received = mask.getValue('');
+    var isValid = mask.validate(received);
+
+    expect(isValid).toBe(false)
+});

--- a/lib/masks/zip-code.mask.js
+++ b/lib/masks/zip-code.mask.js
@@ -19,6 +19,6 @@ export default class ZipCodeMask extends BaseMask {
             return value.length === ZIP_CODE_MASK.length;
         }
 
-        return true;
+        return (value.length > 0);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "react-native-masked-text",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "abab": {
       "version": "1.0.4",
@@ -4075,6 +4074,16 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -4093,16 +4102,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,12 @@
 		"type": "git",
 		"url": "git+https://github.com/benhurott/react-native-masked-text.git"
 	},
-	"keywords": ["mask", "text", "textinput", "react-native"],
+	"keywords": [
+		"mask",
+		"text",
+		"textinput",
+		"react-native"
+	],
 	"author": "Ben-hur Santos Ott",
 	"license": "ISC",
 	"bugs": {


### PR DESCRIPTION
Created a test that checks for empty string in ZipCode, which expects invalid. Before fix, this test failed, now it passes.

See zip-code.mask.js and zip-code.mask.test.js.