### PR TITLE
Moved typings dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
 	"homepage": "https://github.com/benhurott/react-native-masked-text#readme",
 	"dependencies": {
 		"moment": "2.19.3",
-		"tinymask": "^1.0.2",
-		"@types/react-native": "*",
-		"@types/react": "*"
+		"tinymask": "^1.0.2"
 	},
 	"devDependencies": {
+		"@types/react-native": "*",
+		"@types/react": "*",
 		"babel-cli": "^6.26.0",
 		"babel-preset-react-native": "^1.9.1",
 		"jest": "^19.0.2",


### PR DESCRIPTION
`@types/*` should be added as `devDependencies`. 

Otherwise, it could conflict with different versions of `@type` definition in the project, as follows:

```
./node_modules/react-native-masked-text/node_modules/@types/react-native/globals.d.ts(66,3): error TS2717: Subsequent property declarations must have the same type.  Property 'body' must be of type 'string | ArrayBuffer | ArrayBufferView | Blob | FormData', but here has type 'BodyInit_'.
./node_modules/react-native-masked-text/node_modules/@types/react-native/globals.d.ts(92,14): error TS2300: Duplicate identifier 'RequestInfo'.
./node_modules/react-native-masked-text/node_modules/@types/react-native/globals.d.ts(111,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Response' must be of type '{ new (body?: any, init?: ResponseInit): Response; prototype: Response; error: () => Response; re...', but here has type '{ new (body?: BodyInit_, init?: ResponseInit): Response; prototype: Response; error: () => Respon...'.
./node_modules/react-native-masked-text/node_modules/@types/react-native/index.d.ts(9010,11): error TS2451: Cannot redeclare block-scoped variable 'console'.
./node_modules/react-native-masked-text/node_modules/@types/react-native/index.d.ts(9021,11): error TS2451: Cannot redeclare block-scoped variable 'navigator'.
./node_modules/react-native-masked-text/node_modules/@types/react-native/index.d.ts(9031,11): error TS2451: Cannot redeclare block-scoped variable 'originalXMLHttpRequest'.
./node_modules/react-native-masked-text/node_modules/@types/react-native/index.d.ts(9033,11): error TS2451: Cannot redeclare block-scoped variable '__BUNDLE_START_TIME__'.
./node_modules/react-native-masked-text/node_modules/@types/react-native/index.d.ts(9034,11): error TS2451: Cannot redeclare block-scoped variable 'ErrorUtils'.
./node_modules/react-native-masked-text/node_modules/@types/react-native/index.d.ts(9041,11): error TS2451: Cannot redeclare block-scoped variable '__DEV__'.
```
