### PR TITLE
Make credit card issuer optional for other types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ export interface TextInputMaskOptionProp {
 
     // Credit card type.
     obfuscated?: boolean
-    issuer: 'visa-or-mastercard' | 'diners' | 'amex'
+    issuer?: 'visa-or-mastercard' | 'diners' | 'amex'
 
     // Custom type.
     mask?: string


### PR DESCRIPTION
This will fix my local for now but in the future, can consider making it a generic class with `TextInputMask<T extends TextInputMaskTypeProp>` and `type: T` representing the type. Then propagate the generic argument and make `TextInputMaskProps<T>` and `TextInputMaskOptionProp<T>`.  Finally, you can use https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html to select the right subset of properties.

If the money properties were in a type called `TextInputMaskOptionMoneyProp` and the phone ones were in `TextInputMaskOptionPhoneProp`, then I believe you can do `type TextInputMaskOptionProp<T> = T extends "money" ? TextInputMaskOptionMoneyProp : T extends "phone" ? TextInputMaskOptionPhoneProp : etc...`.

This way, the user will see exactly the properties they need based on the original `type=` prop.