### PR TITLE
Add empty value option for custom value for money masked input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ Sample code ([source](https://github.com/benhurott/react-native-masked-text-samp
     separator: ',',
     delimiter: '.',
     unit: 'R$',
-    suffixUnit: ''
+    suffixUnit: '',
+    emptyValue: '',
   }}
   value={this.state.advanced}
   onChangeText={text => {
@@ -504,6 +505,7 @@ Sample code ([source](https://github.com/benhurott/react-native-masked-text-samp
 | delimiter | string | no | `.` | The thousand separator |
 | unit | string | no | `R$` | The prefix text |
 | suffixUnit | string | no | `''` | The sufix text |
+| emptyValue | string | no | `0` | The empty field value |
 
 
 #### Methods

--- a/lib/internal-dependencies/vanilla-masker.js
+++ b/lib/internal-dependencies/vanilla-masker.js
@@ -29,7 +29,8 @@
           //unit: opts.unit && (opts.unit.replace(/[\s]/g,'') + " ") || "",
           suffixUnit: opts.suffixUnit && (" " + opts.suffixUnit.replace(/[\s]/g,'')) || "",
           zeroCents: opts.zeroCents,
-          lastOutput: opts.lastOutput
+          lastOutput: opts.lastOutput,
+          emptyValue: opts.emptyValue || "0"
         };
         opts.moneyPrecision = opts.zeroCents ? 0 : opts.precision;
         return opts;
@@ -149,7 +150,7 @@
       masked += money[i];
     }
     masked = masked.replace(clearDelimiter, "");
-    masked = masked.length ? masked : "0";
+    masked = masked.length ? masked : emptyValue;
     if (!opts.zeroCents) {
       var beginCents = number.length - opts.precision,
           centsValue = number.substr(beginCents, opts.precision),


### PR DESCRIPTION
Possible to add empty value for money inputs. 
Related issue:
https://github.com/benhurott/react-native-masked-text/issues/25