### PR TITLE
Fix MaskService Type Definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ If you want, we expose the `MaskService`. You can use it:
 
 -   static toMask(type, value, settings): mask a value.
     -   `type` (String, required): the type of the mask (`cpf`, `datetime`, etc...)
-    -   `value` (String, required): the value to be masked
+    -   `value` (Number, required): the value to be masked
     -   `settings` (Object, optional): if the mask type accepts options, pass it in the settings parameter
 -   static toRawValue(type, maskedValue, settings): get the raw value of a masked value.
     -   `type` (String, required): the type of the mask (`cpf`, `datetime`, etc...)

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,14 +72,14 @@ export class TextMask extends React.Component<TextInputMaskProps> {}
 export namespace MaskService {
     function toMask(
         type: string,
-        value: string,
+        value: number,
         options?: TextInputMaskOptionProp
     ): string
     function toRawValue(
         type: string,
         maskedValue: string,
         options?: TextInputMaskOptionProp
-    ): string
+    ): number
     function isValid(
         type: string,
         value: string,
@@ -90,7 +90,7 @@ export namespace MaskService {
 // TextInputMaskMethods
 export class TextInputMaskMethods {
     getElement(): TextInput
-    getRawValue(): string
+    getRawValue(): number
     isValid(): boolean
 }
 


### PR DESCRIPTION
toMask is not the opposite of toRawValue.

Trying to follow the actual type definition you will get issues like this:

```js
const formatOptions = {
    precision: 2,
    separator: ',',
    delimiter: '.',
    unit: 'R$ ',
    suffixUnit: '',
};
// Wrong Type: The method will return a number(300) while the type definition expect a string
var rawValue = MaskService.toRawValue('money', 'R$ 300,00', formatOptions); // 300

// Typescript error: Argument of type 'number' is not assignable to parameter of type 'string'.ts(2345)
// The method will run fine but the user will got a typescript error
var maskedValue = MaskService.toMask('money', rawValue, formatOptions); // 'R$ 300,00'

// Casting the parameter to string will remove the typescript issue but may introduce some
// unexpected behaviors
var rawValue = ''+rawValue; // '300'
var maskedValue = MaskService.toMask('money', rawValue, formatOptions); // 'R$ 3,00'
```