### PR TITLE
Fix MaskService 'type' parameter type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,17 +71,17 @@ export class TextMask extends React.Component<TextInputMaskProps> {}
 // MaskService
 export namespace MaskService {
     function toMask(
-        type: string,
+        type: TextInputMaskTypeProp,
         value: string,
         options?: TextInputMaskOptionProp
     ): string
     function toRawValue(
-        type: string,
+        type: TextInputMaskTypeProp,
         maskedValue: string,
         options?: TextInputMaskOptionProp
     ): string
     function isValid(
-        type: string,
+        type: TextInputMaskTypeProp,
         value: string,
         options?: TextInputMaskOptionProp
     ): boolean


### PR DESCRIPTION
Type Definition to **type** parameter on _MaskService_ must be equal to Type Definition to **type** prop on _TextInputMaskProps_

A possible workaround to fix Lint issue until PR is approved:
```js
import {
  TextInputMask,
  TextInputMaskTypeProp,
} from 'react-native-masked-text';

<TextInputMask
      type={type as TextInputMaskTypeProp}
      {...props}
   />
```

```js
    MaskService.toMask(type as string, value , options)
```